### PR TITLE
[IN PROGRESS] First working version of show diff on JAR content

### DIFF
--- a/lib/puppet/type/archive.rb
+++ b/lib/puppet/type/archive.rb
@@ -19,6 +19,13 @@ Puppet::Type.newtype(:archive) do
 
     defaultto(:present)
 
+    # Does not seem to be executed but should be a nicer way to do the show_diff before catalog apply
+    def pre_run_check
+      if Puppet[:show_diff]
+        provider.show_diff
+      end
+    end
+
     # The following changes allows us to notify if the resource is being replaced
     def is_to_s(value) # rubocop:disable Style/PredicateName
       return "(#{resource[:checksum_type]})#{provider.archive_checksum}" if provider.archive_checksum
@@ -68,6 +75,18 @@ Puppet::Type.newtype(:archive) do
     newvalues(:true, :false)
     defaultto(:false)
   end
+
+  newparam(:show_diff) do
+    desc 'shows diff will show every file that has changed in the archive'
+    newvalues(:true, :false)
+    defaultto(:true)
+  end
+
+  # newparam(:noop) do
+  #   desc 'systematically overrides noop'
+  #   newvalues(:true, :false)
+  #   defaultto(:false)
+  # end
 
   newparam(:extract_path) do
     desc 'target folder path to extract archive.'


### PR DESCRIPTION
- ruby provider will override extract method, if show_diff is specified globally it will extract the JAR in a tmp folder, untemplate files, and diff everyfile in it
- For no, always ecessary to override noop in the archive puppet declaration if you run job in noop mode

example of `puppet_archive_test.pp`

```
archive { '/tmp/helloworld.jar':
  path          => '/tmp/helloworld.jar',
  extract       => true,
  extract_path  => '/tmp/helloworld',
  creates       => "${homedir}/nonexisting", 
  # Always leave noop set to false, so show diff can work
  noop    => false,
}
```

You can run the following command to : `puppet apply --modulepath=modules puppet_archive_test.pp --debug --verbose --show_diff`

**Not fully working yet or to improve:**
- Not specifying show-diff should still exract the archive
- Allow unpacking/templating without diff ?
-  No support for target folder removal (force clean)
- No support for repack yet (JAR > untemplate > JAR)
- Facter is probbably not called in the right way (it dumps quite some crap and should use the cached facts)
- Full support of noop mode (run extract method even in noop without specifying it in ressource)
- Hiera support
